### PR TITLE
Add system printout and add paths for vscode

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,11 @@
             "name": "linux-arm-gcc",
             "includePath": [
                 "${workspaceFolder}/**",
-                "${workspaceFolder}/source/**"
+                "${workspaceFolder}/source/**",
+                "${workspaceFolder}/source/periph/**",
+                "${workspaceFolder}/source/debug_usart1/**",
+                "${workspaceFolder}/source/swo_debug/**",
+                "${workspaceFolder}/source/threads/**"
             ],
             "defines": [
                 "_DEBUG",
@@ -21,7 +25,11 @@
             "name": "win-arm",
             "includePath": [
                 "${workspaceFolder}/**",
-                "${workspaceFolder}/source/**"
+                "${workspaceFolder}/source/**",
+                "${workspaceFolder}/source/periph/**",
+                "${workspaceFolder}/source/debug_usart1/**",
+                "${workspaceFolder}/source/swo_debug/**",
+                "${workspaceFolder}/source/threads/**"
             ],
             "defines": [
                 "_DEBUG",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "lldb.showDisassembly": "auto",
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",
     "editor.insertSpaces": true,
@@ -12,5 +11,6 @@
             "column": 80,
             "color": "#19c639",
         }
-    ]
+    ],
+    "lldb.displayFormat": "auto"
 }

--- a/main.c
+++ b/main.c
@@ -87,6 +87,7 @@ int main(void)
      * Normal main() thread activity, spawning shells.
      */
 	while (true) {
-		chThdSleepMilliseconds(500);
+		chThdSleepSeconds(5);
+		print_hal_conf();
 	}
 }


### PR DESCRIPTION
VScode sometimes cannot resolve paths in the project.
It is needed to update vscode config.